### PR TITLE
Fix write offset of SN[8]

### DIFF
--- a/atsha204a/src/cmd.c
+++ b/atsha204a/src/cmd.c
@@ -374,7 +374,7 @@ int cmd_get_serialnbr(struct io_interface *ioif, uint8_t *buf, size_t size)
 		goto err;
 
 	ret = cmd_read(ioif, ZONE_CONFIG, SERIALNBR_ADDR8, SERIALNBR_OFFSET8,
-		       WORD_SIZE, serial_nbr + SERIALNBR_SIZE4_7,
+		       WORD_SIZE, serial_nbr + SERIALNBR_SIZE0_3 + SERIALNBR_SIZE4_7,
 		       SERIALNBR_SIZE8);
 err:
 	if (ret == STATUS_OK)


### PR DESCRIPTION
Currently SN[8] is written to serial_nbr[4]. Update this to the correct
offset, ie serial_nbr[8].

Signed-off-by: Michalis Pappas <mpappas@fastmail.fm>