### PR TITLE
Pass Mode and SlotID to the HMAC command

### DIFF
--- a/atsha204a/include/cmd.h
+++ b/atsha204a/include/cmd.h
@@ -128,7 +128,7 @@ int cmd_get_config_zone(struct io_interface *ioif, uint8_t *buf, size_t size);
 
 int cmd_get_devrev(struct io_interface *ioif, uint8_t *buf, size_t size);
 
-int cmd_get_hmac(struct io_interface *ioif, uint8_t mode, uint8_t *hmac);
+int cmd_get_hmac(struct io_interface *ioif, uint8_t mode, uint16_t slotnbr, uint8_t *hmac);
 
 int cmd_get_lock_config(struct io_interface *ioif, uint8_t *lock_config);
 

--- a/atsha204a/src/main.c
+++ b/atsha204a/src/main.c
@@ -116,7 +116,7 @@ int main(int argc, char *argv[])
 	printf("\n - HMAC -\n");
 	/* 1 << 2 is to set the TempKey.SourceFlag, since we just above did a
 	 * passthrough nonce and therefore we used no internal randomness. */
-	ret = cmd_get_hmac(ioif, 1 << 2, buf);
+	ret = cmd_get_hmac(ioif, 1 << 2, 0, buf);
 	CHECK_RES("hmac", ret, buf, HMAC_LEN);
 #endif
 


### PR DESCRIPTION
Update get_hmac() to pass mode and slotnbr to cmd_packet parameters