### PR TITLE
Fix length flag in cmd_read()

### DIFF
--- a/atsha204a/src/cmd.c
+++ b/atsha204a/src/cmd.c
@@ -133,7 +133,7 @@ int cmd_read(struct io_interface *ioif, uint8_t zone, uint8_t addr,
 	if (zone == ZONE_OTP)
 		zone &= ~(1 << 7);
 	else if (data_size == 32)
-		zone &= (1 << 7);
+		zone |= (1 << 7);
 
 	p.param1 = zone;
 	p.param2[0] = addr;


### PR DESCRIPTION
This patch fixes a bug where the incorrect operator is used
when setting the 32 / 4 bytes flag in cmd_read()

Signed-off-by: Michalis Pappas <mpappas@fastmail.fm>