### PR TITLE
Complete the implementation of cmd_write()

### DIFF
--- a/atsha204a/include/cmd.h
+++ b/atsha204a/include/cmd.h
@@ -149,5 +149,5 @@ int cmd_get_slot_config(struct io_interface *ioif, uint8_t slotnbr,
 			uint16_t *buf);
 
 int cmd_write(struct io_interface *ioif, uint8_t zone, uint8_t addr,
-	      uint8_t *data, size_t size);
+	      bool encrypted, uint8_t *data, size_t size);
 #endif

--- a/atsha204a/src/crc.c
+++ b/atsha204a/src/crc.c
@@ -2,7 +2,7 @@
 #include <debug.h>
 #include <packet.h>
 
-/* 
+/*
  * Computes and check that the computed CRC is the same as the one provided as
  * an argument to the function.
  *
@@ -32,8 +32,6 @@ uint16_t get_serialized_crc(void *p, size_t size)
  * Compute the CRC for a certain payload. This function takes a crc
  * (current_crc) as an argument. This is useful if you cannot compute the entire
  * CRC in one go.
- *
- * Implementation originates from the mysensors.org project.
  */
 uint16_t calculate_crc16(const uint8_t *data, size_t size, uint16_t current_crc)
 {

--- a/atsha204a/src/personalize.c
+++ b/atsha204a/src/personalize.c
@@ -94,9 +94,8 @@ static int program_data_slots(struct io_interface *ioif, uint16_t *crc)
 		*crc = calculate_crc16(data, sizeof(data), *crc);
 
 		logd("Storing: %d bytes, 0x%02x...0x%02x (running CRC: 0x%04x)\n", sizeof(data), data[0], data[31], *crc);
-		//ret = cmd_write(ioif, ZONE_DATA, SLOT_ADDR(i), data, sizeof(data));
+		//ret = cmd_write(ioif, ZONE_DATA, SLOT_ADDR(i), false, data, sizeof(data));
 		ret = STATUS_OK;
-
 		if (ret != STATUS_OK) {
 			loge("Failed to program data slot: %d\n", i);
 			break;
@@ -128,9 +127,8 @@ static int program_otp_zone(struct io_interface *ioif, uint16_t *crc)
 		 */
 		*crc = calculate_crc16(data, sizeof(data), *crc);
 		logd("Storing: %d bytes, 0x%02x...0x%02x (running CRC: 0x%04x)\n", sizeof(data), data[0], data[3], *crc);
-		//  ret = cmd_write(ioif, ZONE_OTP, OTP_ADDR(i), data, sizeof(data));
+		//  ret = cmd_write(ioif, ZONE_OTP, OTP_ADDR(i), false, data, sizeof(data));
 		ret = STATUS_OK;
-
 		if (ret != STATUS_OK) {
 			loge("Failed to program OTP address: 0x%02x\n", OTP_ADDR(i));
 			break;
@@ -151,7 +149,7 @@ static int program_slot_configs(struct io_interface *ioif)
 		     2*i, slot_configs[i].value[0], slot_configs[i].value[1],
 		     (2*i)+1, slot_configs[i].value[2], slot_configs[i].value[3]);
 
-		ret = cmd_write(ioif, ZONE_CONFIG, slot_configs[i].address,
+		ret = cmd_write(ioif, ZONE_CONFIG, slot_configs[i].address, false,
 				slot_configs[i].value, sizeof(slot_configs[i].value));
 
 		if (ret != STATUS_OK) {

--- a/atsha204a/src/personalize.c
+++ b/atsha204a/src/personalize.c
@@ -94,8 +94,7 @@ static int program_data_slots(struct io_interface *ioif, uint16_t *crc)
 		*crc = calculate_crc16(data, sizeof(data), *crc);
 
 		logd("Storing: %d bytes, 0x%02x...0x%02x (running CRC: 0x%04x)\n", sizeof(data), data[0], data[31], *crc);
-		//ret = cmd_write(ioif, ZONE_DATA, SLOT_ADDR(i), false, data, sizeof(data));
-		ret = STATUS_OK;
+		ret = cmd_write(ioif, ZONE_DATA, SLOT_ADDR(i), false, data, sizeof(data));
 		if (ret != STATUS_OK) {
 			loge("Failed to program data slot: %d\n", i);
 			break;
@@ -113,24 +112,31 @@ static int program_data_slots(struct io_interface *ioif, uint16_t *crc)
  */
 static int program_otp_zone(struct io_interface *ioif, uint16_t *crc)
 {
-	int i;
+	int i, j;
 	int ret = STATUS_EXEC_ERROR;
-	uint8_t data[4] = { 0 };
+	uint8_t data[32] = { 0 };
 
-	for (i = 0; i < 16; i++) {
+	/* Before Data/OTP zones are locked, only 32-byte values
+	 * can be written (section 8.5.18). We therefore need to
+	 * program the OTP in terms of blocks, which correspond
+	 * to address 0x00 and 0x10.
+	 */
+	for (i = 0; i < 2; i++) {
 		/* 00...00, 11...11, 22...22, ..., ff..ff */
-		memset(&data, i << 4 | i, sizeof(data));
+		for (j = 0; j < 8; j++) {
+			memset(data + j * 4, (i * 8 + j) << 4 |
+			       (i * 8 + j), 4);
+		}
 
 		/*
 		 * We must update CRC in each loop to be able to return the CRC
 		 * for the entire OTP area.
 		 */
 		*crc = calculate_crc16(data, sizeof(data), *crc);
-		logd("Storing: %d bytes, 0x%02x...0x%02x (running CRC: 0x%04x)\n", sizeof(data), data[0], data[3], *crc);
-		//  ret = cmd_write(ioif, ZONE_OTP, OTP_ADDR(i), false, data, sizeof(data));
-		ret = STATUS_OK;
+		logd("Storing: %d bytes, 0x%02x...0x%02x (running CRC: 0x%04x)\n", sizeof(data), data[0], data[31], *crc);
+		ret = cmd_write(ioif, ZONE_OTP, i * 0x10, false, data, sizeof(data));
 		if (ret != STATUS_OK) {
-			loge("Failed to program OTP address: 0x%02x\n", OTP_ADDR(i));
+			loge("Failed to program OTP address: 0x%02x\n", i * 0x10);
 			break;
 		}
 	}
@@ -176,8 +182,7 @@ static int lock_config_zone(struct io_interface *ioif)
 
 	crc = calculate_crc16(config_zone, sizeof(config_zone), crc);
 
-	/* FIXME: Use CRC here when locking */
-	ret = cmd_lock_zone(ioif, ZONE_CONFIG, NULL);
+	ret = cmd_lock_zone(ioif, ZONE_CONFIG, &crc);
 out:
 	return ret;
 }
@@ -198,6 +203,7 @@ int atsha204a_personalize(struct io_interface *ioif)
 		if (ret != STATUS_OK)
 			goto out;
 	}
+
 	if (is_data_zone_locked(ioif)) {
 		logd("Device data already locked\n");
 	} else {
@@ -207,14 +213,13 @@ int atsha204a_personalize(struct io_interface *ioif)
 		if (ret != STATUS_OK)
 			goto out;
 
-		logd("Intermedia CRC: 0x%04x\n", crc);
+		logd("Intermediate CRC: 0x%04x\n", crc);
 		ret = program_otp_zone(ioif, &crc);
 		if (ret != STATUS_OK)
 			goto out;
 
 		logd("Final CRC: 0x%04x\n", crc);
-		/* FIXME: User CRC value to ensure data is correct. */
-		ret = cmd_lock_zone(ioif, ZONE_DATA, NULL);
+		ret = cmd_lock_zone(ioif, ZONE_DATA, &crc);
 	}
 out:
 	return ret;


### PR DESCRIPTION
- Add encrypt flag
- Set length bit on 32 byte writes
- Remove duplicate set of timing
- Call write through at204_msg() to enquire the device for
  the command status

Signed-off-by: Michalis Pappas <mpappas@fastmail.fm>