### PR TITLE
Fix atsha204a I2C address

### DIFF
--- a/atsha204a/include/device.h
+++ b/atsha204a/include/device.h
@@ -2,6 +2,6 @@
 #define __DEVICE_H
 
 /* Default I2C address for the ATSHA204a */
-#define ATSHA204A_ADDR 0x60
+#define ATSHA204A_ADDR 0x64
 
 #endif


### PR DESCRIPTION
The default I2C address of atsha204a is 0x64. The current address
of 0x60 is the default address of the atecc508a. This have probably
not been unnoticed due to the fact that both chips have some common
opcodes.