### PR TITLE
Correct .travis.yml to select Arm compiler and not x86

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,5 @@ before_install:
 script:
   - cd atsha204a
   - mkdir -p build && cd build
-  - cmake CMAKE_C_COMPILER=arm-linux-gnueabihf-gcc ..
+  - cmake -DCMAKE_C_COMPILER=arm-linux-gnueabihf-gcc ..
   - make

--- a/atsha204a/CMakeLists.txt
+++ b/atsha204a/CMakeLists.txt
@@ -6,6 +6,8 @@ cmake_minimum_required(VERSION 3.0.2)
 
 set(PROJECT_VERSION "0.1.0")
 
+MESSAGE(STATUS "CMAKE_C_COMPILER: " ${CMAKE_C_COMPILER})
+
 add_compile_options(-Wall -Werror)
 include_directories(include)
 


### PR DESCRIPTION
Signed-off-by: Joakim Bech <joakim.bech@linaro.org>