### PR TITLE
Fix error message in cmd_read() to print the correct zone name

### DIFF
--- a/atsha204a/src/cmd.c
+++ b/atsha204a/src/cmd.c
@@ -173,7 +173,7 @@ int cmd_read(struct io_interface *ioif, uint8_t zone, uint8_t addr,
 	if (ret == STATUS_OK)
 		memcpy(data, &resp_buf[offset], data_size);
 	else
-		loge("Failed to read from config zone!\n");
+		loge("Failed to read from %s zone!\n", zone2str(zone));
 
 	return ret;
 }


### PR DESCRIPTION
Signed-off-by: Michalis Pappas <mpappas@fastmail.fm>