### PR TITLE
Add gcc option for C99

### DIFF
--- a/s96at/CMakeLists.txt
+++ b/s96at/CMakeLists.txt
@@ -8,7 +8,7 @@ set(PROJECT_VERSION "0.1.0")
 
 MESSAGE(STATUS "CMAKE_C_COMPILER: " ${CMAKE_C_COMPILER})
 
-add_compile_options(-Wall -Werror)
+add_compile_options(-Wall -Werror -std=gnu99)
 include_directories(include)
 
 set(SRC ${CMAKE_SOURCE_DIR}/src/s96at.c


### PR DESCRIPTION
Add std=gnu99 to build using C99 with GNU extensions

Signed-off-by: Michalis Pappas <mpappas@fastmail.fm>