### PR TITLE
Update device wake

### DIFF
--- a/s96at/include/cmd.h
+++ b/s96at/include/cmd.h
@@ -62,8 +62,6 @@ enum {
 #define PKT_FUNC_IDLE		0x2
 #define PKT_FUNC_COMMAND	0x3
 
-#define CMD_WAKEUP 0x0
-
 /* OP-codes for each command, see section 8.5.4 in spec */
 #define OPCODE_DERIVEKEY	0x1c
 #define OPCODE_DEVREV 		0x30
@@ -154,8 +152,6 @@ uint8_t cmd_update_extra(struct io_interface *ioif, uint8_t mode, uint8_t value)
 
 uint8_t cmd_gen_dig(struct io_interface *ioif, const uint8_t *in, size_t in_size,
 		    uint8_t zone, uint16_t slotnbr);
-
-bool cmd_wake(struct io_interface *ioif);
 
 uint8_t cmd_write(struct io_interface *ioif, uint8_t zone, uint8_t addr,
 		  bool encrypted, const uint8_t *data, size_t size);

--- a/s96at/include/io.h
+++ b/s96at/include/io.h
@@ -27,6 +27,7 @@ struct io_interface {
 	size_t (*write)(void *ctx, const void *buf, size_t size);
 	size_t (*read)(void *ctx, void *buf, size_t size);
 	uint32_t (*close)(void *ctx);
+	uint32_t (*wake)(void *ctx);
 };
 
 uint32_t register_io_interface(uint8_t io_interface_type,
@@ -37,6 +38,7 @@ int at204_write(struct io_interface *ioif, void *buf, size_t size);
 int at204_write2(struct io_interface *ioif, struct cmd_packet *p);
 int at204_read(struct io_interface *ioif, void *buf, size_t size);
 int at204_close(struct io_interface *ioif);
+int at204_wake(struct io_interface *ioif);
 int at204_msg(struct io_interface *ioif, struct cmd_packet *p, void *resp_buf,
 	      size_t size);
 #endif

--- a/s96at/include/s96at.h
+++ b/s96at/include/s96at.h
@@ -12,6 +12,7 @@
 #define S96AT_STATUS_OK				0x00
 #define S96AT_STATUS_CHECKMAC_FAIL		0x01
 #define S96AT_STATUS_EXEC_ERROR			0x0f
+#define S96AT_STATUS_READY			0x11
 #define S96AT_STATUS_PADDING_ERROR		0x98
 #define S96AT_STATUS_BAD_PARAMETERS		0x99
 
@@ -396,7 +397,7 @@ uint8_t s96at_read(struct s96at_desc *desc, enum s96at_zone zone, uint8_t id, ui
  * current command execution or IO state. It is therefore required that all operations
  * are completed within S96AT_WATCHDOG_TIME.
  *
- * Returns S96AT_STATUS_OK on success, otherwise S96AT_STATUS_EXEC_ERROR.
+ * Returns S96AT_STATUS_READY on device wake, otherwise S96AT_STATUS_EXEC_ERROR.
  */
 uint8_t s96at_wake(struct s96at_desc *desc);
 

--- a/s96at/src/cmd.c
+++ b/s96at/src/cmd.c
@@ -102,21 +102,6 @@ void get_command(struct cmd_packet *p, uint8_t opcode)
 	}
 }
 
-bool cmd_wake(struct io_interface *ioif)
-{
-	int ret = STATUS_EXEC_ERROR;
-	ssize_t n = 0;
-	uint8_t cmd = CMD_WAKEUP;
-	uint8_t buf;
-
-	n = at204_write(ioif, &cmd, sizeof(cmd));
-	if (n <= 0)
-		return false;
-
-	ret = at204_read(ioif, &buf, sizeof(buf));
-	return ret == STATUS_OK || ret == STATUS_AFTER_WAKE;
-}
-
 uint8_t cmd_read(struct io_interface *ioif, uint8_t zone, uint8_t addr,
 		 uint8_t offset, size_t size, void *data, size_t data_size)
 {

--- a/s96at/src/io.c
+++ b/s96at/src/io.c
@@ -101,6 +101,11 @@ int at204_close(struct io_interface *ioif)
 	return ioif->close(ioif->ctx);
 }
 
+int at204_wake(struct io_interface *ioif)
+{
+	return ioif->wake(ioif->ctx);
+}
+
 int at204_write2(struct io_interface *ioif, struct cmd_packet *p)
 {
 	uint8_t *serialized_pkt = NULL;

--- a/s96at/src/s96at.c
+++ b/s96at/src/s96at.c
@@ -39,10 +39,18 @@ uint8_t s96at_cleanup(struct s96at_desc *desc)
 
 uint8_t s96at_wake(struct s96at_desc *desc)
 {
-	if (cmd_wake(desc->ioif) == true)
-		return S96AT_STATUS_OK;
-	else
+	uint8_t ret;
+	uint8_t buf;
+
+	if (at204_wake(desc->ioif) != STATUS_OK)
 		return S96AT_STATUS_EXEC_ERROR;
+
+	ret = at204_read(desc->ioif, &buf, sizeof(buf));
+
+	if (ret == S96AT_STATUS_OK && buf == S96AT_STATUS_READY)
+		ret = S96AT_STATUS_READY;
+
+	return ret;
 }
 
 uint8_t s96at_derive_key(struct s96at_desc *desc, uint8_t slot, uint8_t *mac,

--- a/s96at/tests/tests.c
+++ b/s96at/tests/tests.c
@@ -824,7 +824,7 @@ int main(int argc, char *argv[])
 	}
 
 	logd("\n - Wake -\n");
-	while (!s96at_wake(&desc)) {};
+	while (s96at_wake(&desc) != S96AT_STATUS_READY) {};
 	logd("ATSHA204A is awake\n");
 
 	for (int i = 0 ; tests[i].func != NULL; i++) {


### PR DESCRIPTION
Move wake to io operations, as the means of pulling SDA to low
depends on the capabilities of the I2C driver.

Improve wake on i2c_linux. SDA is now pulled low continuously,
by transmitting to address 0x00.

Update s96at_wake() to return S96AT_STATUS_READY on wake.

Signed-off-by: Michalis Pappas <mpappas@fastmail.fm>