### PR TITLE
Fix cmd_lock return value

### DIFF
--- a/s96at/src/cmd.c
+++ b/s96at/src/cmd.c
@@ -237,6 +237,8 @@ uint8_t cmd_lock_zone(struct io_interface *ioif, uint8_t zone,
 	 */
 	if (ret == STATUS_OK && resp_buf == LOCK_DATA_LOCKED)
 		logd("Successfully locked %s zone!\n", zone2str(zone));
+	else
+		ret = STATUS_EXEC_ERROR;
 out:
 	return ret;
 }


### PR DESCRIPTION
Update the return value of cmd_lock() to return success
under the condition that the command has returned STATUS_OK,
AND the output buffer contains the value that indicates that
locking was successful.

Signed-off-by: Michalis Pappas <mpappas@fastmail.fm>